### PR TITLE
chore(renovate): group vite overrides with devDependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,5 +21,10 @@
       ],
       groupName: 'devDependencies (non-major)',
     },
+    {
+      matchPackageNames: ['vite'],
+      matchDepTypes: ['overrides'],
+      groupName: 'devDependencies (non-major)',
+    },
   ],
 }


### PR DESCRIPTION
Vite overrides were being treated separately from devDependencies, causing Renovate grouping errors. Add a rule to group vite overrides with the devDependencies (non-major) group.