### PR TITLE
chore(ci): use flake inputs for Node.js version alignment

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,7 +4,7 @@ description: Setup Node.js environment via Nix
 runs:
   using: composite
   steps:
-    - run: nix profile install nixpkgs#nodejs_24
+    - run: nix profile install nixpkgs#nodejs_24 --inputs-from .
       shell: bash
     - run: npm ci
       shell: bash


### PR DESCRIPTION
Use --inputs-from . flag to align the Node.js version in CI with the local development environment defined in flake.nix